### PR TITLE
Support multiple sort columns

### DIFF
--- a/src/stSort.js
+++ b/src/stSort.js
@@ -31,6 +31,21 @@ ng.module('smart-table')
 
           var func;
           predicate = ng.isFunction(getter(scope)) || ng.isArray(getter(scope)) ? getter(scope) : attr.stSort;
+          
+          // Support array
+          if (ng.isString(predicate) && predicate.includes("[")) {
+            var parr = predicate.replace(/'/g, '"');
+
+            try {
+              parr = JSON.parse(parr);
+              if (ng.isArray(parr)) {
+                predicate = parr;
+              }
+            } catch (e) {
+                // not an array
+            }
+          }
+          
           if (index % 3 === 0 && !!skipNatural !== true) {
             //manual reset
             index = 0;


### PR DESCRIPTION
Support multiple sort columns by allowing an array of property names to be passed via the *st-sort* attribute.

Example:

```HTML
<table st-table="items">
   <tr st-sort="['id', 'name']">ID</tr>
  <tr st-sort="name">Name</tr>
  <tr st-sort="['phone', 'name']">Phone</tr>
</table>
```
This will allow for the first parameter to act as the primary sort predicate, and then will sort the sorted results using the second property as predicate.